### PR TITLE
fix(render): Append .cshtml extension to custom field paths

### DIFF
--- a/staging/Dynamic Form.cshtml
+++ b/staging/Dynamic Form.cshtml
@@ -43,7 +43,7 @@
           @* If it's a advanced field, use the custom razor - otherwise use FormBuilder from base class *@
           @if (field.UseRazorComponent)
           {
-            @Html.Partial("./razor-fields/" + field.RazorFile, new { field })
+            @Html.Partial("./razor-fields/" + field.RazorFile + ".cshtml", new { field })
           }
           else
           {


### PR DESCRIPTION
The rendering logic for custom Razor fields was failing because it passed the field's filename without the .cshtml extension to Html.Partial.

In the target environment, the rendering engine does not automatically append the extension, which caused a compilation error. This change explicitly concatenates the ".cshtml" string to the path, resolving the issue for all custom fields.